### PR TITLE
Replace dotenv with python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
-dotenv
+python-dotenv
 schedule
 pytest


### PR DESCRIPTION
## Summary
- replace deprecated `dotenv` package reference

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: ProxyError - api.topstepx.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fb6f6d8cc832eaea5c7260c047042