### PR TITLE
Remove stray os file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .DS_Store
 
 .env
+os


### PR DESCRIPTION
## Summary
- remove leftover `os` file
- ignore `os` in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'topstepx_trader')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685086752488832e94c91a71ba100a75