### PR TITLE
Refactor paths after folder reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd QuantX
 
 python3 -m venv venv
 source venv/bin/activate  # On Windows use: venv\Scripts\activate
-pip install -r requirements.txt
+pip install -r config/requirements.txt
 
 3. Setup JavaScript Environment
 
@@ -59,15 +59,15 @@ Shell 1: Start Flask Bridge
 source venv/bin/activate  # (or Windows equivalent)
 export FLASK_APP=backend/app.py
 export FLASK_ENV=development
-PYTHONPATH=. flask run --port=5000
+PYTHONPATH=./backend flask run --port=5000
 
 Shell 2: Start Vite Frontend
 
-npm run dev
+npm run dev  # serves ./frontend via Vite
 
 Shell 3: Start Electron Shell
 
-npm start #or npm run electron
+npm start # or npm run electron (entry: electron/main.js)
 
 📂 .env
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -33,8 +33,7 @@ const config = {
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: "v8",
-  rootDir: "..",
-  roots: ["<rootDir>/tests/js"],
+  roots: ["<rootDir>/../tests/js"],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [

--- a/electron/main.js
+++ b/electron/main.js
@@ -18,7 +18,7 @@ ipcMain.handle('search-accounts', async () => {
 
 ipcMain.handle('run-tests', async () => {
   const { exec } = require('child_process');
-  const env = { ...process.env, PYTHONPATH: rootDir };
+  const env = { ...process.env, PYTHONPATH: path.join(rootDir, 'backend') };
   return new Promise(resolve => {
     exec('pytest tests/python', {
       cwd: rootDir,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ["./src/**/*.{js,jsx,ts,tsx,html}"],
+  content: ["./frontend/**/*.{js,jsx,ts,tsx,html}"],
   darkMode: 'class', // or 'media' if preferred
   theme: {
     extend: {},

--- a/tests/python/test_accounts.py
+++ b/tests/python/test_accounts.py
@@ -6,6 +6,8 @@ import os
 from backend.topstepx_trader.accounts import search_accounts
 from backend.topstepx_trader.auth import authenticate
 
+LOG_DIR = "logs"
+
 def test_search_accounts():
     load_dotenv(override=True)
     token = authenticate()
@@ -34,7 +36,8 @@ def test_search_accounts():
     result = search_accounts()
     accounts = result.get("accounts", [])
 
-    with open("account_log.json", "w") as f:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(os.path.join(LOG_DIR, "account_log.json"), "w") as f:
         json.dump(accounts, f, indent=2)
 
     print("[DEBUG] API Returned Accounts:", json.dumps(accounts, indent=2))

--- a/tests/python/test_contracts.py
+++ b/tests/python/test_contracts.py
@@ -3,6 +3,9 @@ import pytest
 from dotenv import load_dotenv
 from backend.topstepx_trader.contracts import search_contracts, search_contract_by_id
 import json
+import os
+
+LOG_DIR = "logs"
 
 def test_search_contracts():
     load_dotenv(override=True)
@@ -10,7 +13,8 @@ def test_search_contracts():
     assert result is not None
     assert result.get("success") is True
     assert "contracts" in result
-    with open("contracts_log.json", "w") as f:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(os.path.join(LOG_DIR, "contracts_log.json"), "w") as f:
         json.dump(result.get("contracts"), f, indent=2)
     print("[TEST OUTPUT] Contracts returned:", json.dumps(result.get("contracts"), indent=2))
 
@@ -20,6 +24,7 @@ def test_search_contract_by_id():
     assert result is not None
     assert result.get("success") is True
     assert "contract" in result
-    with open("contract_by_id_log.json", "w") as f:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(os.path.join(LOG_DIR, "contract_by_id_log.json"), "w") as f:
         json.dump(result.get("contract"), f, indent=2)
     print("[TEST OUTPUT] Contract by ID returned:", json.dumps(result.get("contract"), indent=2))

--- a/tests/python/test_retrieve_bars.py
+++ b/tests/python/test_retrieve_bars.py
@@ -3,6 +3,9 @@ import pytest
 from dotenv import load_dotenv
 from backend.topstepx_trader.retrieve_bars import retrieve_bars
 import json
+import os
+
+LOG_DIR = "logs"
 
 
 def test_retrieve_bars():
@@ -11,6 +14,7 @@ def test_retrieve_bars():
     assert result is not None
     assert result.get("success") is True
     assert "bars" in result
-    with open("bars_log.json", "w") as f:
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(os.path.join(LOG_DIR, "bars_log.json"), "w") as f:
         json.dump(result.get("bars"), f, indent=2)
     print("[TEST OUTPUT] Bars returned:", json.dumps(result.get("bars"), indent=2))

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  root: 'src',
+  root: 'frontend',
   build: {
     outDir: '../dist',
     emptyOutDir: true,
@@ -11,7 +11,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      '@': path.resolve(__dirname, 'frontend'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- fix Electron test runner PYTHONPATH to point at backend
- update Jest root paths after moving config
- update Vite/Tailwind configs for new frontend folder
- log Python test artifacts to `logs/`
- refresh README instructions for new layout

## Testing
- `pip install -r config/requirements.txt`
- `PYTHONPATH=. pytest tests/python/test_scheduler.py -q`
