### PR TITLE
Ensure logs directory exists in tests

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def ensure_logs_dir():
+    os.makedirs("logs", exist_ok=True)
+    return "logs"
+

--- a/tests/python/test_accounts.py
+++ b/tests/python/test_accounts.py
@@ -34,7 +34,8 @@ def test_search_accounts():
     result = search_accounts()
     accounts = result.get("accounts", [])
 
-    with open("account_log.json", "w") as f:
+    log_path = os.path.join("logs", "account_log.json")
+    with open(log_path, "w") as f:
         json.dump(accounts, f, indent=2)
 
     print("[DEBUG] API Returned Accounts:", json.dumps(accounts, indent=2))

--- a/tests/python/test_contracts.py
+++ b/tests/python/test_contracts.py
@@ -3,6 +3,7 @@ import pytest
 from dotenv import load_dotenv
 from topstepx_trader.contracts import search_contracts, search_contract_by_id
 import json
+import os
 
 def test_search_contracts():
     load_dotenv(override=True)
@@ -10,7 +11,8 @@ def test_search_contracts():
     assert result is not None
     assert result.get("success") is True
     assert "contracts" in result
-    with open("contracts_log.json", "w") as f:
+    log_path = os.path.join("logs", "contracts_log.json")
+    with open(log_path, "w") as f:
         json.dump(result.get("contracts"), f, indent=2)
     print("[TEST OUTPUT] Contracts returned:", json.dumps(result.get("contracts"), indent=2))
 
@@ -20,6 +22,7 @@ def test_search_contract_by_id():
     assert result is not None
     assert result.get("success") is True
     assert "contract" in result
-    with open("contract_by_id_log.json", "w") as f:
+    log_path = os.path.join("logs", "contract_by_id_log.json")
+    with open(log_path, "w") as f:
         json.dump(result.get("contract"), f, indent=2)
     print("[TEST OUTPUT] Contract by ID returned:", json.dumps(result.get("contract"), indent=2))

--- a/tests/python/test_retrieve_bars.py
+++ b/tests/python/test_retrieve_bars.py
@@ -3,6 +3,7 @@ import pytest
 from dotenv import load_dotenv
 from topstepx_trader.retrieve_bars import retrieve_bars
 import json
+import os
 
 
 def test_retrieve_bars():
@@ -11,6 +12,7 @@ def test_retrieve_bars():
     assert result is not None
     assert result.get("success") is True
     assert "bars" in result
-    with open("bars_log.json", "w") as f:
+    log_path = os.path.join("logs", "bars_log.json")
+    with open(log_path, "w") as f:
         json.dump(result.get("bars"), f, indent=2)
     print("[TEST OUTPUT] Bars returned:", json.dumps(result.get("bars"), indent=2))


### PR DESCRIPTION
## Summary
- write test logs to `logs/` directory
- create a session fixture that ensures `logs/` exists before tests run

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'topstepx_trader')*

------
https://chatgpt.com/codex/tasks/task_e_68509ba7fe64832e95dea4238db0653e