### PR TITLE
Fix README paths and electron sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd QuantX
 
 python3 -m venv venv
 source venv/bin/activate  # On Windows use: venv\Scripts\activate
-pip install -r config/requirements.txt
+pip install -r requirements.txt
 
 3. Setup JavaScript Environment
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const axios = require('axios');
 const rootDir = path.join(__dirname, '..');
+app.commandLine.appendSwitch('no-sandbox');
 
 ipcMain.handle('save-config', async (_, config) => {
   const envTarget = path.join(rootDir, '.env');

--- a/frontend/renderer/index.html
+++ b/frontend/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>TopstepX Trading App</title>
-  <link rel="stylesheet" href="../assets/styles.css" />
+  <link rel="stylesheet" href="../../assets/styles.css" />
 </head>
 <body>
   <header>

--- a/frontend/renderer/onboarding.html
+++ b/frontend/renderer/onboarding.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Onboarding</title>
-  <link rel="stylesheet" href="../assets/styles.css" />
+  <link rel="stylesheet" href="../../assets/styles.css" />
 </head>
 <body>
   <h1>Welcome to TopstepX</h1>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "QuantX Electron Frontend",
   "main": "electron/main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "electron . --no-sandbox",
     "test": "jest --config config/jest.config.js",
     "dev": "vite",
     "build": "vite build"


### PR DESCRIPTION
## Summary
- fix Python install command in README
- point renderer HTML to correct CSS path
- allow Electron to run as root with `--no-sandbox`

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm test`
